### PR TITLE
Updated newHeader tests to accept either innerHTML or innerText

### DIFF
--- a/test/indexTest.js
+++ b/test/indexTest.js
@@ -1,20 +1,38 @@
 describe("index.html", () => {
   describe("after index.js is processed", () => {
     it("no longer has DOM node 'main#main'", () => {
-      expect(document.querySelector('main'), "Make sure you remove the <main> with id 'main'").to.not.exist
+      expect(
+        document.querySelector("main"),
+        "Make sure you remove the <main> with id 'main'"
+      ).to.not.exist;
     });
 
     it("has a 'newHeader' variable that points to node 'h1#victory'", () => {
-      expect(newHeader.nodeName, "Make sure you create an <h1> with id 'victory'").eql('H1')
+      expect(
+        newHeader.nodeName,
+        "Make sure you create an <h1> with id 'victory'"
+      ).eql("H1");
     });
 
     it("has a 'newHeader' variable that points to node 'h1#victory'", () => {
-      expect(newHeader.id, "Make sure you create an <h1> with id 'victory'").eql('victory')
+      expect(
+        newHeader.id,
+        "Make sure you create an <h1> with id 'victory'"
+      ).eql("victory");
     });
 
     it("has a 'newHeader' variable that points to node 'h1#victory' with \"YOUR-NAME is the champion\" inside", () => {
-      expect(newHeader.innerHTML, "Make sure you create an <h1> with id 'victory' with a sweet message in it").to.include("is the champion");
+      try {
+        expect(
+          newHeader.innerHTML,
+          "Make sure you create an <h1> with id 'victory' with a sweet message in it"
+        ).to.include("is the champion");
+      } catch {
+        expect(
+          newHeader.innerText,
+          "Make sure you create an <h1> with id 'victory' with a sweet message in it"
+        ).to.include("is the champion");
+      }
     });
-
   });
-})
+});


### PR DESCRIPTION
Updated tests to newHeader to accept either innerHTML or innerText, since both methods can insert text into a node.